### PR TITLE
site: update references to github/git-lfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Getting started minisite for Git LFS.
 
 To preview:
 
-1. Clone locally: `git clone https://github.com/github/git-lfs.github.com.git`
+1. Clone locally: `git clone https://github.com/git-lfs/git-lfs.github.com.git`
 2. Run Jekyll: `script/server`
 3. View in browser locally at: [localhost:4000](http://localhost:4000)
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,9 +8,9 @@
       </a>
 
       <nav class="site-nav">
-        <a class="page-link" href="https://github.com/github/git-lfs/tree/master/docs?utm_source=gitlfs_site&amp;utm_medium=docs_link&amp;utm_campaign=gitlfs">Docs</a>
-        <a class="page-link" href="https://github.com/github/git-lfs/releases/latest?utm_source=gitlfs_site&amp;utm_medium=downloads_link&amp;utm_campaign=gitlfs">Downloads</a>
-        <a class="page-link" href="https://github.com/github/git-lfs?utm_source=gitlfs_site&amp;utm_medium=source_link&amp;utm_campaign=gitlfs">Source</a>
+        <a class="page-link" href="https://github.com/git-lfs/git-lfs/tree/master/docs?utm_source=gitlfs_site&amp;utm_medium=docs_link&amp;utm_campaign=gitlfs">Docs</a>
+        <a class="page-link" href="https://github.com/git-lfs/git-lfs/releases/latest?utm_source=gitlfs_site&amp;utm_medium=downloads_link&amp;utm_campaign=gitlfs">Downloads</a>
+        <a class="page-link" href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=source_link&amp;utm_campaign=gitlfs">Source</a>
       </nav>
 
     </div>

--- a/_includes/home/hero.html
+++ b/_includes/home/hero.html
@@ -8,16 +8,16 @@
       <p class="description">Git Large File Storage (LFS) replaces large files such as audio samples, videos, datasets, and graphics with text pointers inside Git, while storing the file contents on a remote server like GitHub.com or GitHub Enterprise.</p>
       <div class="js-download">
         <a class="button primary-cta js-os-data" data-ga-params="download,button" data-os-attr="href"
-           href="https://github.com/github/git-lfs/releases/latest"
-           data-os-mac="https://github.com/github/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-{{site.git-lfs-release}}.tar.gz"
-           data-os-windows="https://github.com/github/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-{{site.git-lfs-release}}.exe">
+           href="https://github.com/git-lfs/git-lfs/releases/latest"
+           data-os-mac="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-{{site.git-lfs-release}}.tar.gz"
+           data-os-windows="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-{{site.git-lfs-release}}.exe">
           <span class="octicon octicon-cloud-download"></span>
           Download <span class="download-details">v{{site.git-lfs-release}}<span class="js-os-data" data-os-attr="text" data-os-mac=" (Mac)" data-os-Windows=" (Windows)"><span></span>
         </a>
       </div>
       <div class="js-linux visually-hidden">
         <a href="https://packagecloud.io/github/git-lfs/install" class="button primary-cta js-os-data" data-ga-params="download,packagecloud"><span class="octicon octicon-cloud-download"></span> Install <span class="download-details">v{{site.git-lfs-release}} via PackageCloud (Linux)</span></a>
-        <p class="secondary-download">or <a href="https://github.com/github/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-{{site.git-lfs-release}}.tar.gz" data-ga-params="download,button">Download v{{site.git-lfs-release}} (Linux)</a></p>
+        <p class="secondary-download">or <a href="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-{{site.git-lfs-release}}.tar.gz" data-ga-params="download,button">Download v{{site.git-lfs-release}} (Linux)</a></p>
       </div>
       <div class="js-mac visually-hidden">
         <p class="secondary-download">

--- a/_includes/home/secondary.html
+++ b/_includes/home/secondary.html
@@ -3,10 +3,10 @@
 
     <div class="column">
       <a class="dot-com-announcement js-os-data" data-os-attr="href" data-ga-params="download,banner"
-         href="https://github.com/github/git-lfs/releases/latest"
-         data-os-mac="https://github.com/github/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-{{site.git-lfs-release}}.tar.gz"
-         data-os-windows="https://github.com/github/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-{{site.git-lfs-release}}.exe"
-         data-os-linux="https://github.com/github/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-{{site.git-lfs-release}}.tar.gz">
+         href="https://github.com/git-lfs/git-lfs/releases/latest"
+         data-os-mac="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-{{site.git-lfs-release}}.tar.gz"
+         data-os-windows="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-{{site.git-lfs-release}}.exe"
+         data-os-linux="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-{{site.git-lfs-release}}.tar.gz">
          GitHub.com support now available. <br/><span>Install the client to get started</span>.</a>
       </a>
 
@@ -21,10 +21,10 @@
         <li>
           <p>
             <a class="js-os-data" data-os-attr="href" data-ga-params="download,link"
-               href="https://github.com/github/git-lfs/releases/latest"
-               data-os-mac="https://github.com/github/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-{{site.git-lfs-release}}.tar.gz"
-               data-os-windows="https://github.com/github/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-{{site.git-lfs-release}}.exe"
-               data-os-linux="https://github.com/github/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-{{site.git-lfs-release}}.tar.gz">
+               href="https://github.com/git-lfs/git-lfs/releases/latest"
+               data-os-mac="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-{{site.git-lfs-release}}.tar.gz"
+               data-os-windows="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-{{site.git-lfs-release}}.exe"
+               data-os-linux="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-{{site.git-lfs-release}}.tar.gz">
                Download
             </a>
             and install the Git command line extension. You only have to set up Git LFS once.
@@ -45,11 +45,11 @@ git push origin master</pre>
 
       <h2 class="section-heading">Git LFS is an open source project</h2>
 
-      <p>To file an issue or contribute to the project, head over <a href="https://github.com/github/git-lfs?utm_source=gitlfs_site&amp;utm_medium=repo_link&amp;utm_campaign=gitlfs">to the repository</a>
-        or read our <a href="https://github.com/github/git-lfs/blob/master/CONTRIBUTING.md?utm_source=gitlfs_site&amp;utm_medium=contributing_link&amp;utm_campaign=gitlfs">guide to contributing</a>.</p>
+      <p>To file an issue or contribute to the project, head over <a href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=repo_link&amp;utm_campaign=gitlfs">to the repository</a>
+        or read our <a href="https://github.com/git-lfs/git-lfs/blob/master/CONTRIBUTING.md?utm_source=gitlfs_site&amp;utm_medium=contributing_link&amp;utm_campaign=gitlfs">guide to contributing</a>.</p>
       <p>If you're interested in integrating Git LFS into another tool or product, you might want to read the
-        <a href="https://github.com/github/git-lfs/blob/master/docs/api/README.md?utm_source=gitlfs_site&amp;utm_medium=api_spec_link&amp;utm_campaign=gitlfs">API specification</a>
-        or check out our <a href="https://github.com/github/lfs-test-server?utm_source=gitlfs_site&amp;utm_medium=reference_servedr&amp;utm_campaign=gitlfs">reference server implementation</a>.</p>
+        <a href="https://github.com/git-lfs/git-lfs/blob/master/docs/api/README.md?utm_source=gitlfs_site&amp;utm_medium=api_spec_link&amp;utm_campaign=gitlfs">API specification</a>
+        or check out our <a href="https://github.com/git-lfs/lfs-test-server?utm_source=gitlfs_site&amp;utm_medium=reference_servedr&amp;utm_campaign=gitlfs">reference server implementation</a>.</p>
 
     </div><!-- /.home-getting-started -->
 


### PR DESCRIPTION
This PR updates all references to the old `github/git-lfs` repo its new home at `git-lfs/git-lfs`. ✨ 

I left packagecloud.io as-is for now, since it doesn't yet understand GitHub redirects.

As an aside, I found these references by running:

```
$ grep -r "github/git-lfs" . | grep -v ".git/" | cut -d ' ' -f 1 | uniq
```

/cc @technoweenie 
