### PR TITLE
config: update version to v1.3.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 title: "Git Large File Storage"
 description: "Git Large File Storage (LFS) replaces large files such as audio samples, videos, datasets, and graphics with text pointers inside Git, while storing the file contents on a remote server like GitHub.com or GitHub Enterprise."
-git-lfs-release: 1.2.1
+git-lfs-release: 1.3.0
 
 url: "https://git-lfs.github.com"
 


### PR DESCRIPTION
This PR updates the latest release of Git LFS to be `v1.3.0`. This PR should _not_ be merged until git-lfs/git-lfs#1388 is merged 😄 