### PR TITLE
Add the checking in of .gitattributes to the default instructions

### DIFF
--- a/_includes/home/secondary.html
+++ b/_includes/home/secondary.html
@@ -37,7 +37,8 @@
         </li>
         <li>
           <p>There is no step three. Just commit and push to GitHub as you normally would.</p>
-<pre>git add file.psd
+<pre>git add .gitattributes
+git add file.psd
 git commit -m "Add design file"
 git push origin master</pre>
         </li>

--- a/_includes/home/secondary.html
+++ b/_includes/home/secondary.html
@@ -34,10 +34,12 @@
         <li>
           <p>Select the file types you'd like Git LFS to manage (or directly edit your .gitattributes). You can configure additional file extensions at anytime.</p>
 <pre>git lfs track "*.psd"</pre>
+          <p>Make sure .gitattributes is tracked</p>
+<pre>git add .gitattributes</pre>
         </li>
         <li>
           <p>There is no step three. Just commit and push to GitHub as you normally would.</p>
-<pre>git add .gitattributes
+<pre>
 git add file.psd
 git commit -m "Add design file"
 git push origin master</pre>


### PR DESCRIPTION
I just noticed that the default instructions for using git-lfs are omitting the checking in of .gitattributes, contrary to the instructions at:
- https://help.github.com/articles/configuring-git-large-file-storage
- and https://github.com/git-lfs/git-lfs

This is a very minor PR to help people make the right turn when they use git-lfs for the first time.