### PR TITLE
config: bump to version v2.1.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 title: "Git Large File Storage"
 description: "Git Large File Storage (LFS) replaces large files such as audio samples, videos, datasets, and graphics with text pointers inside Git, while storing the file contents on a remote server like GitHub.com or GitHub Enterprise."
-git-lfs-release: 2.1.0
+git-lfs-release: 2.1.1
 
 url: "https://git-lfs.github.com"
 


### PR DESCRIPTION
This pull request bumps the 'Download Now' button to link to the latest Git LFS release, v2.1.1.

---

/cc @git-lfs/core 