### PR TITLE
home/hero.html: fix download link

### DIFF
--- a/_includes/home/hero.html
+++ b/_includes/home/hero.html
@@ -9,15 +9,15 @@
       <div class="js-download">
         <a class="button primary-cta js-os-data" data-ga-params="download,button" data-os-attr="href"
            href="https://github.com/git-lfs/git-lfs/releases/latest"
-           data-os-mac="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-{{site.git-lfs-release}}.tar.gz"
-           data-os-windows="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-{{site.git-lfs-release}}.exe">
+           data-os-mac="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-v{{site.git-lfs-release}}.tar.gz"
+           data-os-windows="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-v{{site.git-lfs-release}}.exe">
           <span class="octicon octicon-cloud-download"></span>
           Download <span class="download-details">v{{site.git-lfs-release}}<span class="js-os-data" data-os-attr="text" data-os-mac=" (Mac)" data-os-Windows=" (Windows)"><span></span>
         </a>
       </div>
       <div class="js-linux visually-hidden">
         <a href="https://packagecloud.io/github/git-lfs/install" class="button primary-cta js-os-data" data-ga-params="download,packagecloud"><span class="octicon octicon-cloud-download"></span> Install <span class="download-details">v{{site.git-lfs-release}} via PackageCloud (Linux)</span></a>
-        <p class="secondary-download">or <a href="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-{{site.git-lfs-release}}.tar.gz" data-ga-params="download,button">Download v{{site.git-lfs-release}} (Linux)</a></p>
+        <p class="secondary-download">or <a href="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-v{{site.git-lfs-release}}.tar.gz" data-ga-params="download,button">Download v{{site.git-lfs-release}} (Linux)</a></p>
       </div>
       <div class="js-mac visually-hidden">
         <p class="secondary-download">


### PR DESCRIPTION
Prior to v2.5.0, Git LFS named packaged release artifacts as:

    git-lfs-darwin-amd64-2.4.0.tar.gz

and etc., for combinations of OS, architecture, version, and archival
format.

In v2.5.0, we began naming those same release artifacts as:

    git-lfs-darwin-amd64-v2.5.0.tar.gz

Noting that there is now a 'v' prefix for the version number. In lieu of
changing this back to the sans-'v' format, let's keep this and continue
to name versions as-is from here going forward.

This will help alleviate some whiplash experienced by packaging
maintainers who have updated scripts to account for this new name, and
it will be easier to maintain in Git LFS's somewhat-complicated
Makefile.

So, given that this change is here to stay (and we only ever increase
the version number ;-) ), let's update the link on the website to
download the appropriate thing, and not 404.

Closes: https://github.com/git-lfs/git-lfs.github.com/issues/32.

##

/cc @git-lfs/core 