### PR TITLE
home/secondary.html: clarify install and setup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,3 +28,4 @@ exclude:
   - LICENSE.txt
   - README.md
   - script
+  - vendor/bundle/

--- a/_includes/home/secondary.html
+++ b/_includes/home/secondary.html
@@ -25,16 +25,17 @@
                data-os-mac="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-v{{site.git-lfs-release}}.tar.gz"
                data-os-windows="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-v{{site.git-lfs-release}}.exe"
                data-os-linux="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-v{{site.git-lfs-release}}.tar.gz">Download</a>
-            and install the Git command line extension. Once downloaded and installed, set up Git LFS and its respective hooks by running:
+            and install the Git command line extension. Once downloaded and installed, set up Git LFS for your user account by running:
           </p>
           <pre>git lfs install</pre>
-          <p>You'll need to run this in your repository directory, once per repository.</p>
+          <p>You only need to run this once per user account.</p>
         </li>
         <li>
-          <p>Select the file types you'd like Git LFS to manage (or directly edit your .gitattributes). You can configure additional file extensions at anytime.</p>
+          <p>In each Git repository where you want to use Git LFS, select the file types you'd like Git LFS to manage (or directly edit your .gitattributes). You can configure additional file extensions at anytime.</p>
 <pre>git lfs track "*.psd"</pre>
-          <p>Make sure .gitattributes is tracked</p>
+          <p>Now make sure .gitattributes is tracked:</p>
 <pre>git add .gitattributes</pre>
+          <p>Note that defining the file types Git LFS should track will not, by itself, convert any pre-existing files to Git LFS, such as files on other branches or in your prior commit history. To do that, use the <a href="https://github.com/git-lfs/git-lfs/blob/master/docs/man/git-lfs-migrate.1.ronn?utm_source=gitlfs_site&amp;utm_medium=doc_man_migrate_link&amp;utm_campaign=gitlfs">git lfs migrate[1]</a> command, which has a range of options designed to suit various potential use cases.</p>
         </li>
         <li>
           <p>There is no step three. Just commit and push to GitHub as you normally would.</p>


### PR DESCRIPTION
We further clarify the documentation on the home page regarding how and when to install and configure LFS, distinguishing the normal one-time (per user) install step from the per-repository tracking setup steps, and also noting the `git lfs migrate` command and its use in dealing with pre-existing files.

This builds on the clarifications added in PR #37 (commit 3eb274c3f246e01c481e4f52431b3909453210bc), and should resolve git-lfs/git-lfs#4032.

(We also add a line to `_config.yml` to exclude the `vendor/bundle/` directory when running a local Jekyll server for test purposes; otherwise, Jekyll tries to parse its own date-formatting tests—which contains an intentionally invalid date—and fails to start.  See https://github.com/jekyll/jekyll/issues/5267#issuecomment-241379902 and https://github.com/jekyll/jekyll/issues/2938#issuecomment-131456094, and the notes in the Jekyll [Troubleshooting](https://jekyllrb.com/docs/troubleshooting/#configuration-problems) documentation.)

/cc @bk2204 
/cc @ccschneidr as reporter