### PR TITLE
Rename default branch to main

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
       </a>
 
       <nav class="site-nav">
-        <a class="page-link" href="https://github.com/git-lfs/git-lfs/tree/master/docs?utm_source=gitlfs_site&amp;utm_medium=docs_link&amp;utm_campaign=gitlfs">Docs</a>
+        <a class="page-link" href="https://github.com/git-lfs/git-lfs/tree/main/docs?utm_source=gitlfs_site&amp;utm_medium=docs_link&amp;utm_campaign=gitlfs">Docs</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/releases/latest?utm_source=gitlfs_site&amp;utm_medium=downloads_link&amp;utm_campaign=gitlfs">Downloads</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=source_link&amp;utm_campaign=gitlfs">Source</a>
       </nav>

--- a/_includes/home/secondary.html
+++ b/_includes/home/secondary.html
@@ -31,7 +31,7 @@
 <pre>git lfs track "*.psd"</pre>
           <p>Now make sure .gitattributes is tracked:</p>
 <pre>git add .gitattributes</pre>
-          <p>Note that defining the file types Git LFS should track will not, by itself, convert any pre-existing files to Git LFS, such as files on other branches or in your prior commit history. To do that, use the <a href="https://github.com/git-lfs/git-lfs/blob/master/docs/man/git-lfs-migrate.1.ronn?utm_source=gitlfs_site&amp;utm_medium=doc_man_migrate_link&amp;utm_campaign=gitlfs">git lfs migrate[1]</a> command, which has a range of options designed to suit various potential use cases.</p>
+          <p>Note that defining the file types Git LFS should track will not, by itself, convert any pre-existing files to Git LFS, such as files on other branches or in your prior commit history. To do that, use the <a href="https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-migrate.1.ronn?utm_source=gitlfs_site&amp;utm_medium=doc_man_migrate_link&amp;utm_campaign=gitlfs">git lfs migrate[1]</a> command, which has a range of options designed to suit various potential use cases.</p>
         </li>
         <li>
           <p>There is no step three. Just commit and push to GitHub as you normally would; for instance, if your current branch is named <code>main</code>:</p>
@@ -45,9 +45,9 @@ git push origin main</pre>
       <h2 class="section-heading">Git LFS is an open source project</h2>
 
       <p>To file an issue or contribute to the project, head over <a href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=repo_link&amp;utm_campaign=gitlfs">to the repository</a>
-        or read our <a href="https://github.com/git-lfs/git-lfs/blob/master/CONTRIBUTING.md?utm_source=gitlfs_site&amp;utm_medium=contributing_link&amp;utm_campaign=gitlfs">guide to contributing</a>.</p>
+        or read our <a href="https://github.com/git-lfs/git-lfs/blob/main/CONTRIBUTING.md?utm_source=gitlfs_site&amp;utm_medium=contributing_link&amp;utm_campaign=gitlfs">guide to contributing</a>.</p>
       <p>If you're interested in integrating Git LFS into another tool or product, you might want to read the
-        <a href="https://github.com/git-lfs/git-lfs/blob/master/docs/api/README.md?utm_source=gitlfs_site&amp;utm_medium=api_spec_link&amp;utm_campaign=gitlfs">API specification</a>
+        <a href="https://github.com/git-lfs/git-lfs/blob/main/docs/api/README.md?utm_source=gitlfs_site&amp;utm_medium=api_spec_link&amp;utm_campaign=gitlfs">API specification</a>
         or check out our <a href="https://github.com/git-lfs/lfs-test-server?utm_source=gitlfs_site&amp;utm_medium=reference_servedr&amp;utm_campaign=gitlfs">reference server implementation</a>.</p>
 
     </div><!-- /.home-getting-started -->


### PR DESCRIPTION
As outlined in git-lfs/git-lfs#4153, we'd like to change the default branch name to `main`.  In order to do so, let's update the links to our documentation so that they continue to work correctly.