### PR TITLE
Update to v2.13.3 release and correct macOS download link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 title: "Git Large File Storage"
 description: "Git Large File Storage (LFS) replaces large files such as audio samples, videos, datasets, and graphics with text pointers inside Git, while storing the file contents on a remote server like GitHub.com or GitHub Enterprise."
-git-lfs-release: 2.13.2
+git-lfs-release: 2.13.3
 
 url: "https://git-lfs.github.com"
 

--- a/_includes/home/secondary.html
+++ b/_includes/home/secondary.html
@@ -18,7 +18,7 @@
           <p>
             <a class="js-os-data" data-os-attr="href" data-ga-params="download,link"
                href="https://github.com/git-lfs/git-lfs/releases/latest"
-               data-os-mac="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-v{{site.git-lfs-release}}.tar.gz"
+               data-os-mac="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-v{{site.git-lfs-release}}.zip"
                data-os-windows="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-v{{site.git-lfs-release}}.exe"
                data-os-linux="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-v{{site.git-lfs-release}}.tar.gz">Download</a>
             and install the Git command line extension. Once downloaded and installed, set up Git LFS for your user account by running:


### PR DESCRIPTION
In commit 12d0190fbdd75e687cec73fe92c4e2aead768db0 the main "hero" download link was updated to offer a Zip archive file link for macOS instead of a gzipped tarball, and a secondary link was also updated in that same commit.  That link was then subsequently removed.

However, another secondary link which still exists was never updated, so we change it now to offer the Zip archive file.

We also update the release version number to the latest release, v2.13.3.