### PR TITLE
add wiki and discussion links to index page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,6 +9,7 @@
 
       <nav class="site-nav">
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/tree/main/docs?utm_source=gitlfs_site&amp;utm_medium=docs_link&amp;utm_campaign=gitlfs">Docs</a>
+        <a class="page-link" href="https://github.com/git-lfs/git-lfs/wiki?utm_source=gitlfs_site&amp;utm_medium=wiki_link&amp;utm_campaign=gitlfs">Wiki</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/releases/latest?utm_source=gitlfs_site&amp;utm_medium=downloads_link&amp;utm_campaign=gitlfs">Downloads</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=source_link&amp;utm_campaign=gitlfs">Source</a>
       </nav>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,6 +9,7 @@
 
       <nav class="site-nav">
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/tree/main/docs?utm_source=gitlfs_site&amp;utm_medium=docs_link&amp;utm_campaign=gitlfs">Docs</a>
+        <a class="page-link" href="https://github.com/git-lfs/git-lfs/discussions?utm_source=gitlfs_site&amp;utm_medium=discussions_link&amp;utm_campaign=gitlfs">Discussions</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/wiki?utm_source=gitlfs_site&amp;utm_medium=wiki_link&amp;utm_campaign=gitlfs">Wiki</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/releases/latest?utm_source=gitlfs_site&amp;utm_medium=downloads_link&amp;utm_campaign=gitlfs">Downloads</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=source_link&amp;utm_campaign=gitlfs">Source</a>

--- a/_includes/home/secondary.html
+++ b/_includes/home/secondary.html
@@ -4,7 +4,7 @@
     <div class="column">
       <a class="dot-com-announcement" data-ga-params="banner"
          href="https://github.com/git-lfs/git-lfs/security/advisories/GHSA-cx3w-xqmc-84g5">
-        Git LFS security update:<br/><span>Windows users should update to 2.13.2 or newer</span>.</a>
+        Git LFS security update: <span>Windows users should update to 2.13.2 or newer</span>.</a>
       </a>
     </div>
 

--- a/_includes/home/secondary.html
+++ b/_includes/home/secondary.html
@@ -44,7 +44,7 @@ git push origin main</pre>
 
       <h2 class="section-heading">Git LFS is an open source project</h2>
 
-      <p>To file an issue or contribute to the project, head over <a href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=repo_link&amp;utm_campaign=gitlfs">to the repository</a>
+      <p>To start a discussion, file an issue, or contribute to the project, head over <a href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=repo_link&amp;utm_campaign=gitlfs">to the repository</a>
         or read our <a href="https://github.com/git-lfs/git-lfs/blob/main/CONTRIBUTING.md?utm_source=gitlfs_site&amp;utm_medium=contributing_link&amp;utm_campaign=gitlfs">guide to contributing</a>.</p>
       <p>If you're interested in integrating Git LFS into another tool or product, you might want to read the
         <a href="https://github.com/git-lfs/git-lfs/blob/main/docs/api/README.md?utm_source=gitlfs_site&amp;utm_medium=api_spec_link&amp;utm_campaign=gitlfs">API specification</a>

--- a/_includes/home/secondary.html
+++ b/_includes/home/secondary.html
@@ -39,6 +39,7 @@
 git add file.psd
 git commit -m "Add design file"
 git push origin main</pre>
+          <p>Check out our <a href="https://github.com/git-lfs/git-lfs/wiki?utm_source=gitlfs_site&amp;utm_medium=wiki_link&amp;utm_campaign=gitlfs">wiki</a>, <a href="https://github.com/git-lfs/git-lfs/discussions?utm_source=gitlfs_site&amp;utm_medium=discussions_link&amp;utm_campaign=gitlfs">discussion forum</a>, and <a href="https://github.com/git-lfs/git-lfs/tree/main/docs?utm_source=gitlfs_site&amp;utm_medium=docs_link&amp;utm_campaign=gitlfs">documentation</a> for help with any questions you might have!</p>
         </li>
       </ol>
 


### PR DESCRIPTION
This small PR adds two items to the top-right header on the index page, "Discussions" and "Wiki", which link to the respective pages in the main project repository, and also adds a mention of the Discussions page in the "open source project" section.

Resolves #48.
/cc @HonkingGoose as reporter.