### PR TITLE
revise download buttons and add Apple Silicon option on macOS

### DIFF
--- a/_includes/home/hero.html
+++ b/_includes/home/hero.html
@@ -6,26 +6,51 @@
       <h1 class="page-heading">An open source Git extension for versioning large files</h1>
 
       <p class="description">Git Large File Storage (LFS) replaces large files such as audio samples, videos, datasets, and graphics with text pointers inside Git, while storing the file contents on a remote server like GitHub.com or GitHub Enterprise.</p>
-      <div class="js-download">
-        <a class="button primary-cta js-os-data" data-ga-params="download,button" data-os-attr="href"
-           href="https://github.com/git-lfs/git-lfs/releases/latest"
-           data-os-mac="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-v{{site.git-lfs-release}}.zip"
-           data-os-windows="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-v{{site.git-lfs-release}}.exe">
-          <span class="octicon octicon-cloud-download"></span>
-          Download <span class="download-details">v{{site.git-lfs-release}}<span class="js-os-data" data-os-attr="text" data-os-mac=" (Mac)" data-os-Windows=" (Windows)"><span></span>
-        </a>
-      </div>
-      <div class="js-linux visually-hidden">
-        <a href="https://packagecloud.io/github/git-lfs/install" class="button primary-cta js-os-data" data-ga-params="download,packagecloud"><span class="octicon octicon-cloud-download"></span> Install <span class="download-details">v{{site.git-lfs-release}} via PackageCloud (Linux)</span></a>
-        <p class="secondary-download">or <a href="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-v{{site.git-lfs-release}}.tar.gz" data-ga-params="download,button">Download v{{site.git-lfs-release}} (Linux)</a></p>
-      </div>
-      <div class="js-mac visually-hidden">
-        <p class="secondary-download">
-          <a href="http://brew.sh">Homebrew</a>: <code>brew install git-lfs</code><br>
-          <a href="https://www.macports.org">MacPorts</a>: <code>port install git-lfs</code>
+      <div class="js-windows visually-hidden">
+        <p>
+          <a class="button primary-cta" data-ga-params="download,button"
+              href="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-v{{site.git-lfs-release}}.exe">
+            <span class="octicon octicon-cloud-download"></span>
+            Download <span class="download-details">v{{site.git-lfs-release}} (Windows)</span>
+          </a>
         </p>
       </div>
-
+      <div class="js-mac visually-hidden">
+        <p>
+          <a class="button primary-cta" data-ga-params="download,button"
+              href="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-v{{site.git-lfs-release}}.zip">
+            <span class="octicon octicon-cloud-download"></span>
+            Download <span class="download-details">v{{site.git-lfs-release}} (Mac - Intel Silicon)&nbsp;&nbsp;</span>
+          </a>
+        </p>
+        <p>
+          <a class="button primary-cta" data-ga-params="download,button"
+              href="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-arm64-v{{site.git-lfs-release}}.zip">
+            <span class="octicon octicon-cloud-download"></span>
+            Download <span class="download-details">v{{site.git-lfs-release}} (Mac - Apple Silicon)</span>
+          </a>
+        </p>
+        <p class="secondary-download">
+          <a href="http://brew.sh">Homebrew</a>: <code>brew install git-lfs</code><br>
+          <a href="https://www.macports.org">MacPorts</a>:&nbsp;&nbsp;&nbsp; <code>port install git-lfs</code>
+        </p>
+      </div>
+      <div class="js-linux visually-hidden">
+        <p>
+          <a class="button primary-cta" data-ga-params="download,packagecloud"
+              href="https://packagecloud.io/github/git-lfs/install">
+            <span class="octicon octicon-cloud-download"></span>
+            Install <span class="download-details">v{{site.git-lfs-release}} via PackageCloud (Linux)</span>
+         </a>
+        </p>
+        <p>
+          <a class="button primary-cta" data-ga-params="download,button"
+              href="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-v{{site.git-lfs-release}}.tar.gz">
+            <span class="octicon octicon-cloud-download"></span>
+            Download <span class="download-details">v{{site.git-lfs-release}} (Linux - x86-64)</span>
+          </a>
+        </p>
+      </div>
     </div>
 
     <div class="column-half column graphic">

--- a/_includes/home/secondary.html
+++ b/_includes/home/secondary.html
@@ -16,12 +16,7 @@
       <ol class="install-steps">
         <li>
           <p>
-            <a class="js-os-data" data-os-attr="href" data-ga-params="download,link"
-               href="https://github.com/git-lfs/git-lfs/releases/latest"
-               data-os-mac="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-darwin-amd64-v{{site.git-lfs-release}}.zip"
-               data-os-windows="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-windows-v{{site.git-lfs-release}}.exe"
-               data-os-linux="https://github.com/git-lfs/git-lfs/releases/download/v{{site.git-lfs-release}}/git-lfs-linux-amd64-v{{site.git-lfs-release}}.tar.gz">Download</a>
-            and install the Git command line extension. Once downloaded and installed, set up Git LFS for your user account by running:
+            Download and install the Git command line extension. Once downloaded and installed, set up Git LFS for your user account by running:
           </p>
           <pre>git lfs install</pre>
           <p>You only need to run this once per user account.</p>

--- a/js/_scripts/main.coffee
+++ b/js/_scripts/main.coffee
@@ -1,24 +1,11 @@
 $ ->
-
-  # Set the html attribute specified by `data-os-attr` to the os specific value
-  # specified by `data-os-*`. In which * matches the os string of the current
-  # browser window.
-  #
-  # Usage:
-  # <a href="" class="js-os-data" data-os-attr="href", data-os-mac="" data-os-windows="bar" data-os-linux="bat">
-  #
   os = window.session.browser.os.toLowerCase()
-  $('.js-os-data').each ->
-    $el = $(this)
-    attr = $el.attr('data-os-attr')
-    return unless val = $el.attr("data-os-#{os}")
-    if attr in ['text','html'] then $el[attr](val) else $el.attr(attr, val)
-
   if os == 'mac'
     $('.js-mac').removeClass('visually-hidden')
   else if os == 'linux'
     $('.js-linux').removeClass('visually-hidden')
-    $('.js-download').addClass('visually-hidden')
+  else
+    $('.js-windows').removeClass('visually-hidden')
 
 # Event tracking for clicks on "Download" or Sign Up"
 $(document).on 'click', (e) ->


### PR DESCRIPTION
With the advent of Apple's M1-based systems we now need to offer two download options for macOS users on our home page, as there is no convenient and reliable way to distinguish between hardware platforms in JavaScript.

Therefore we add a second "Apple Silicon" download button for macOS users, and rename the original button "Intel Silicon".

Rather than try to continue the existing practice of sharing the HTML code for the first download button with Windows, we refactor the download button HTML into three sections, one each for Windows, macOS, and Linux.  This in turn allows us to delete the `js-os-data` CoffeeScript as each HTML section is now fully independent.

Having made this change for macOS, it also makes some sense for us to make a parallel change for Linux users, promoting the Intel/AMD x86-64 download option to a button aligned below the packagecloud.io install option button.

Because we now have two primary download options for macOS, and for Linux as well, we drop the hyperlink around the "Download" text in the our set of instructions for new users, as it is not useful to have that text always link to just one of several possible download options.

Lastly we add some simple whitespace-based padding just to make some of our text strings align slightly better in both the macOS and Linux versions of the home page.

The macOS version of the page now renders as:

<img width="685" alt="Screen Shot 2022-02-08 at 10 44 27 PM" src="https://user-images.githubusercontent.com/28857117/153144183-cdfe1989-4727-4a14-bd74-39947552b365.png">

The Linux version now renders as:

<img width="681" alt="Screen Shot 2022-02-08 at 10 44 59 PM" src="https://user-images.githubusercontent.com/28857117/153144222-0983024c-effb-4d38-a750-c82feed8f252.png">

And the Windows version continues to render as it does currently:

<img width="675" alt="Screen Shot 2022-02-08 at 10 45 26 PM" src="https://user-images.githubusercontent.com/28857117/153144257-74a2f654-1377-4ad8-a07b-1fb3b7020ba0.png">


Fixes git-lfs/git-lfs#4836.
/cc @tecandrew as reporter.