### PR TITLE
Change base url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: "Git Large File Storage"
 description: "Git Large File Storage (LFS) replaces large files such as audio samples, videos, datasets, and graphics with text pointers inside Git, while storing the file contents on a remote server like GitHub.com or GitHub Enterprise."
 git-lfs-release: 3.3.0
 
-url: "https://git-lfs.github.com"
+url: "https://git-lfs.com"
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
Since we updated the CNAME in https://github.com/git-lfs/git-lfs.github.com/commit/f87feee582864d160976462551774ced0b28bf5b, this change helps ensure all paths in the HTML generated by Jekyll reflect the correct canonical hostname.