### PR TITLE
Change "Downloads" header link to "Installation" and link to README

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,7 @@
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/tree/main/docs?utm_source=gitlfs_site&amp;utm_medium=docs_link&amp;utm_campaign=gitlfs">Docs</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/discussions?utm_source=gitlfs_site&amp;utm_medium=discussions_link&amp;utm_campaign=gitlfs">Discussions</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/wiki?utm_source=gitlfs_site&amp;utm_medium=wiki_link&amp;utm_campaign=gitlfs">Wiki</a>
-        <a class="page-link" href="https://github.com/git-lfs/git-lfs/releases/latest?utm_source=gitlfs_site&amp;utm_medium=downloads_link&amp;utm_campaign=gitlfs">Downloads</a>
+        <a class="page-link" href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=installation_link&amp;utm_campaign=gitlfs#installing">Installation</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=source_link&amp;utm_campaign=gitlfs">Source</a>
       </nav>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,6 +12,7 @@
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/discussions?utm_source=gitlfs_site&amp;utm_medium=discussions_link&amp;utm_campaign=gitlfs">Discussions</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs/wiki?utm_source=gitlfs_site&amp;utm_medium=wiki_link&amp;utm_campaign=gitlfs">Wiki</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=installation_link&amp;utm_campaign=gitlfs#installing">Installation</a>
+        <a class="page-link" href="https://github.com/git-lfs/git-lfs/releases?utm_source=gitlfs_site&amp;utm_medium=releases_link&amp;utm_campaign=gitlfs">Releases</a>
         <a class="page-link" href="https://github.com/git-lfs/git-lfs?utm_source=gitlfs_site&amp;utm_medium=source_link&amp;utm_campaign=gitlfs">Source</a>
       </nav>
 


### PR DESCRIPTION
As noted in [this pull request](https://github.com/git-lfs/git-lfs/pull/5260), it is currently hard to find installation instructions on the website for an operating system that is not the one that the website is opened on.

I would argue that most users look for "installation" instead of "download" instructions, therefore I think that renaming the header link to "installation" would be it easier discoverable for users.

More over I think that linking to the [README installation instructions](https://github.com/git-lfs/git-lfs#installing) is more helpful than linking directly to the downloadable release binaries. (The README installation instructions include links to the binaries.)

❗ Note that this pull request assumes that the [README pull request](https://github.com/git-lfs/git-lfs/pull/5260) is being accepted and merged since it links to the [`#installing`](https://github.com/git-lfs/git-lfs#installing) section in the README.
The current version only includes instructions to install from binaries or source whereas the new proposed version includes all options.

## Before

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/6301/213690713-265201a9-71c6-4560-9ada-928fb5492e88.png">

## After

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/6301/213728297-27ed8584-2a6a-4afa-9697-72637f3b8dd6.png">


