### PR TITLE
Add "webrick" to Gemfile for Ruby 3 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem 'github-pages', :group => :jekyll_plugins
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
Running `script/server` in a default GitHub codespace yields this error:

```
/usr/local/rvm/gems/ruby-3.1.3/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)
        from /usr/local/rvm/gems/ruby-3.1.3/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `<top (required)>'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:184:in `require_relative'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:184:in `setup'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:102:in `process'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `block in start'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `each'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `start'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
        from /usr/local/rvm/gems/ruby-3.1.3/gems/jekyll-3.9.2/exe/jekyll:15:in `<top (required)>'
        from /usr/local/rvm/gems/ruby-3.1.3/bin/jekyll:25:in `load'
        from /usr/local/rvm/gems/ruby-3.1.3/bin/jekyll:25:in `<main>'
        from /usr/local/rvm/gems/ruby-3.1.3/bin/ruby_executable_hooks:22:in `eval'
        from /usr/local/rvm/gems/ruby-3.1.3/bin/ruby_executable_hooks:22:in `<main>'
```

The reason is that a default GitHub codespace uses Ruby 3 (my codespace used `ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]` to be exact, via `ruby --version`).

The `webrick` gem is no longer a bundled gem in Ruby 3.0, see https://github.com/jekyll/jekyll/issues/8523.
Therefore I propose to add it to the `Gemfile`.

I added the entry by running `bundle add webrick` and confirmed that `script/server` works afterwards.
